### PR TITLE
Enable `Embedded Content Contains Swift Code`, crash on device otherwise

### DIFF
--- a/weTranslate.xcodeproj/project.pbxproj
+++ b/weTranslate.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 				CODE_SIGN_ENTITLEMENTS = weTranslate/weTranslate.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -598,6 +599,7 @@
 				CODE_SIGN_ENTITLEMENTS = weTranslate/weTranslate.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",


### PR DESCRIPTION
http://stackoverflow.com/questions/24002836/dyld-library-not-loaded-rpath-libswift-stdlib-core-dylib
